### PR TITLE
chore: add basic custom prism themes

### DIFF
--- a/website-v2/docusaurus.config.js
+++ b/website-v2/docusaurus.config.js
@@ -83,8 +83,8 @@ module.exports = {
     },
     image: 'img/opengraph.png',
     prism: {
-      theme: require('prism-react-renderer/themes/github'),
-      darkTheme: require('prism-react-renderer/themes/vsDark'),
+      theme: require('./src/prism/themeLight'),
+      darkTheme: require('./src/prism/themeDark'),
     },
     footer: {
       style: 'dark',

--- a/website-v2/src/prism/themeDark.js
+++ b/website-v2/src/prism/themeDark.js
@@ -37,6 +37,13 @@ const themeDark = [
       color: '#65737e',
     },
   },
+  {
+    types: ['inserted'],
+    style: {
+      color: '#b5cea8',
+      background: '#355235',
+    },
+  },
 ];
 
 module.exports = {

--- a/website-v2/src/prism/themeDark.js
+++ b/website-v2/src/prism/themeDark.js
@@ -1,0 +1,48 @@
+const baseTheme = require('prism-react-renderer/themes/vsDark');
+
+const themeDark = [
+  {
+    types: ['keyword'],
+    style: {
+      color: '#469446',
+    },
+  },
+  {
+    types: ['string'],
+    style: {
+      color: '#a49840',
+    },
+  },
+  {
+    types: ['function'],
+    style: {
+      color: '#9e6db1',
+    },
+  },
+  {
+    types: ['operator'],
+    style: {
+      color: '#888',
+    },
+  },
+  {
+    types: ['number', 'variable'],
+    style: {
+      color: '#336b9d',
+    },
+  },
+  {
+    types: ['comment'],
+    style: {
+      color: '#65737e',
+    },
+  },
+];
+
+module.exports = {
+  plain: {
+    backgroundColor: '#242526',
+    color: '#eee',
+  },
+  styles: baseTheme.styles.concat(themeDark),
+};

--- a/website-v2/src/prism/themeLight.js
+++ b/website-v2/src/prism/themeLight.js
@@ -1,0 +1,52 @@
+const baseTheme = require('prism-react-renderer/themes/github');
+
+const themeLight = [
+  {
+    types: ['function'],
+    style: {
+      color: '#6b2e85',
+    },
+  },
+  {
+    types: ['string'],
+    style: {
+      color: '#c21325',
+    },
+  },
+  {
+    types: ['property'],
+    style: {
+      color: '#82772c',
+    },
+  },
+  {
+    types: ['keyword', 'tag'],
+    style: {
+      color: '#297a29',
+    },
+  },
+  {
+    types: ['operator'],
+    style: {
+      color: '#888',
+    },
+  },
+  {
+    types: ['number', 'variable'],
+    style: {
+      color: '#1373c2',
+    },
+  },
+  {
+    types: ['inserted'],
+    style: {
+      color: '#397300',
+      backgroundColor: '#baeeba',
+    },
+  },
+];
+
+module.exports = {
+  plain: Object.assign(baseTheme.plain, {backgroundColor: '#f6f6f6'}),
+  styles: baseTheme.styles.concat(themeLight),
+};

--- a/website-v2/src/prism/themeLight.js
+++ b/website-v2/src/prism/themeLight.js
@@ -41,7 +41,7 @@ const themeLight = [
     types: ['inserted'],
     style: {
       color: '#397300',
-      backgroundColor: '#baeeba',
+      background: '#baeeba',
     },
   },
 ];


### PR DESCRIPTION
## Summary

As mentioned in #1 the default theme pool of prism-react-renderer is not that big, but in the other hand the themes customization isn't complex. 

This PR adds the prism custom themes which are based on the earlier chosen themes with some modification to tokens and CodeBlock background color (as @slorber suggested).

Light theme replicates now the theme used in v1 quite good, the dark theme don't look bad, but for sure can be further improved to match the Jest website styling better.

## Test plan

Local build and run of V2 website.

### Previews
Base on https://jest-v2.netlify.app/docs/puppeteer#custom-example-without-jest-puppeteer-preset page content.
<img width="440" alt="Screenshot 2020-12-04 151539" src="https://user-images.githubusercontent.com/719641/101174779-9d51ec80-3644-11eb-87ff-c15e8bbf150c.png">
<img width="443" alt="Screenshot 2020-12-04 151618" src="https://user-images.githubusercontent.com/719641/101174787-9fb44680-3644-11eb-9ca0-64d068cb22a1.png">

